### PR TITLE
Upgrade dependencies to be compatible with Jakarta EE 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ Add this dependency to your `pom.xml`
     <dependency>
 	    <groupId>org.valid4j</groupId>
 	    <artifactId>http-matchers</artifactId>
-	    <version>1.1</version>
+	    <version>2.0</version>
     </dependency>
 
 The [JAX-RS client API (javax.ws.rs.client)](https://docs.oracle.com/javaee/7/api/index.html?javax/ws/rs/client/package-summary.html)
 can be downloaded from here, but is usually bundled with the client implementation you are using, e.g Jersey.
 
+
     <dependency>
-	    <groupId>javax.ws.rs</groupId>
-	    <artifactId>javax.ws.rs-api</artifactId>
-	    <version>2.0.1</version>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>3.1.0</version>
     </dependency>
 
 ## Usage guide

--- a/pom.xml
+++ b/pom.xml
@@ -6,17 +6,13 @@
 
     <groupId>org.valid4j</groupId>
     <artifactId>http-matchers</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/valid4j/http-matchers</url>
     <description>A set of hamcrest-matchers for JAX-RS</description>
     <inceptionYear>2016</inceptionYear>
-
-    <prerequisites>
-        <maven>2.2.1</maven>
-    </prerequisites>
 
     <licenses>
         <license>
@@ -41,6 +37,11 @@
             <id>guranxp</id>
             <name>Göran Persson</name>
             <email>guranxp@gmail.com</email>
+        </developer>
+        <developer>
+            <id>mederel</id>
+            <name>Emile de Weerd</name>
+            <email>emile@deweerd.fr</email>
         </developer>
     </developers>
 
@@ -69,10 +70,22 @@
     <properties>
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>1.7</jdk.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
+        <jdk.version>17</jdk.version>
+        <hamcrest.version>2.2</hamcrest.version>
+        <jakartaee.version>3.1.0</jakartaee.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.9.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -81,9 +94,9 @@
             <version>${hamcrest.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax.ws.rs-api.version}</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakartaee.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -95,31 +108,41 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
+            <version>1.4.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.22.1</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
-            <version>0.9.2</version>
+            <version>4.0.0-beta.3</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>31.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -129,7 +152,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.10.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <source>${jdk.version}</source>
@@ -145,7 +168,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0-M7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.8</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -158,7 +201,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -171,7 +214,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.4.1</version>
                         <configuration>
                             <quiet>true</quiet>
                         </configuration>
@@ -187,7 +230,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/org/valid4j/matchers/http/HasContentLengthMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasContentLengthMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 class HasContentLengthMatcher extends FeatureMatcher<Response, Integer> {
     public HasContentLengthMatcher(Matcher<? super Integer> lengthMatcher) {

--- a/src/main/java/org/valid4j/matchers/http/HasContentTypeMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasContentTypeMatcher.java
@@ -3,8 +3,8 @@ package org.valid4j.matchers.http;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 class HasContentTypeMatcher extends FeatureMatcher<Response, MediaType> {
 

--- a/src/main/java/org/valid4j/matchers/http/HasCookieMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasCookieMatcher.java
@@ -3,8 +3,8 @@ package org.valid4j.matchers.http;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 class HasCookieMatcher extends TypeSafeMatcher<Response> {

--- a/src/main/java/org/valid4j/matchers/http/HasCookieWithValueMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasCookieWithValueMatcher.java
@@ -4,8 +4,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 class HasCookieWithValueMatcher extends TypeSafeDiagnosingMatcher<Response> {

--- a/src/main/java/org/valid4j/matchers/http/HasEntityMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasEntityMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 class HasEntityMatcher extends TypeSafeMatcher<Response> {
     public void describeTo(Description description) {

--- a/src/main/java/org/valid4j/matchers/http/HasEntityWithValueMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasEntityWithValueMatcher.java
@@ -4,7 +4,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 class HasEntityWithValueMatcher<T> extends TypeSafeDiagnosingMatcher<Response> {
     private final Class<T> entityClass;

--- a/src/main/java/org/valid4j/matchers/http/HasGenericEntityWithValueMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasGenericEntityWithValueMatcher.java
@@ -4,8 +4,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 
 class HasGenericEntityWithValueMatcher<T> extends TypeSafeDiagnosingMatcher<Response> {
     private final GenericType<T> entityType;

--- a/src/main/java/org/valid4j/matchers/http/HasHeaderMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasHeaderMatcher.java
@@ -3,8 +3,8 @@ package org.valid4j.matchers.http;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 class HasHeaderMatcher extends TypeSafeDiagnosingMatcher<Response> {
     private final String headerName;

--- a/src/main/java/org/valid4j/matchers/http/HasHeaderWithValueMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasHeaderWithValueMatcher.java
@@ -4,8 +4,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 class HasHeaderWithValueMatcher extends TypeSafeDiagnosingMatcher<Response> {
     private final String headerName;

--- a/src/main/java/org/valid4j/matchers/http/HasHeaderWithValuesMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasHeaderWithValuesMatcher.java
@@ -4,8 +4,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 class HasHeaderWithValuesMatcher extends TypeSafeDiagnosingMatcher<Response> {

--- a/src/main/java/org/valid4j/matchers/http/HasLastModifiedDate.java
+++ b/src/main/java/org/valid4j/matchers/http/HasLastModifiedDate.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Date;
 
 class HasLastModifiedDate extends FeatureMatcher<Response, Date> {

--- a/src/main/java/org/valid4j/matchers/http/HasLocation.java
+++ b/src/main/java/org/valid4j/matchers/http/HasLocation.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.URI;
 
 class HasLocation extends FeatureMatcher<Response, URI> {

--- a/src/main/java/org/valid4j/matchers/http/HasStatusCodeMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasStatusCodeMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 class HasStatusCodeMatcher extends FeatureMatcher<Response, Integer> {
     public HasStatusCodeMatcher(Matcher<Integer> statusCodeMatcher) {

--- a/src/main/java/org/valid4j/matchers/http/HasStatusMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/HasStatusMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Objects;
 
 class HasStatusMatcher extends TypeSafeMatcher<Response> {

--- a/src/main/java/org/valid4j/matchers/http/HttpResponseMatchers.java
+++ b/src/main/java/org/valid4j/matchers/http/HttpResponseMatchers.java
@@ -2,9 +2,9 @@ package org.valid4j.matchers.http;
 
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.*;
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.Response.StatusType;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.core.Response.Status.Family;
+import jakarta.ws.rs.core.Response.StatusType;
 import java.net.URI;
 import java.util.Date;
 import java.util.Locale;

--- a/src/main/java/org/valid4j/matchers/http/MediaTypeCompatibleWithMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/MediaTypeCompatibleWithMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 class MediaTypeCompatibleWithMatcher extends TypeSafeMatcher<MediaType> {
     private final MediaType compatibleMediaType;

--- a/src/main/java/org/valid4j/matchers/http/NewCookieMatchers.java
+++ b/src/main/java/org/valid4j/matchers/http/NewCookieMatchers.java
@@ -5,7 +5,7 @@ import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.NewCookie;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/main/java/org/valid4j/matchers/http/OfFamilyMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/OfFamilyMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 class OfFamilyMatcher extends TypeSafeMatcher<Integer> {
     private final Response.Status.Family family;

--- a/src/main/java/org/valid4j/matchers/http/OfLanguageMatcher.java
+++ b/src/main/java/org/valid4j/matchers/http/OfLanguageMatcher.java
@@ -3,7 +3,7 @@ package org.valid4j.matchers.http;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Locale;
 
 class OfLanguageMatcher extends FeatureMatcher<Response, Locale> {

--- a/src/test/java/org/valid4j/matchers/http/HttpResponseEntityMatchersTest.java
+++ b/src/test/java/org/valid4j/matchers/http/HttpResponseEntityMatchersTest.java
@@ -1,28 +1,30 @@
 package org.valid4j.matchers.http;
 
-import io.dropwizard.testing.junit.DropwizardClientRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import io.dropwizard.testing.junit5.DropwizardClientExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.extension.ExtendWith;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasContentLength;
 import static org.valid4j.matchers.http.HttpResponseMatchers.hasEntity;
 import static org.valid4j.matchers.http.helpers.MatcherHelpers.mismatchOf;
 import static org.valid4j.matchers.http.helpers.MatcherMatchers.isDescribedBy;
 
-public class HttpResponseEntityMatchersTest {
+@ExtendWith(DropwizardExtensionsSupport.class)
+class HttpResponseEntityMatchersTest {
 
     @Path("text")
     @Produces(MediaType.TEXT_PLAIN)
@@ -45,15 +47,14 @@ public class HttpResponseEntityMatchersTest {
         }
     }
 
-    @ClassRule
-    public final static DropwizardClientRule server = new DropwizardClientRule(
+    public final static DropwizardClientExtension server = new DropwizardClientExtension(
             new TextPayloadResource(),
             new JsonPayloadResource());
 
     public final Client client = ClientBuilder.newClient();
 
     @Test
-    public void shouldMatchByEntityWithStringValue() {
+    void shouldMatchByEntityWithStringValue() {
         Response response = client.target(server.baseUri()).path("text").request().get();
         assertThat(response, hasEntity(String.class, equalTo("some-content-as-payload")));
         assertThat(response, hasEntity(equalTo("some-content-as-payload")));
@@ -64,7 +65,7 @@ public class HttpResponseEntityMatchersTest {
     }
 
     @Test
-    public void shouldMatchByGenericEntityWithStringValues() {
+    void shouldMatchByGenericEntityWithStringValues() {
         Response response = client.target(server.baseUri()).path("json").request().get();
         assertThat(response, hasEntity(
                 new GenericType<Map<String, String>>() {
@@ -73,7 +74,7 @@ public class HttpResponseEntityMatchersTest {
     }
 
     @Test
-    public void shouldMatchByContentLength() {
+    void shouldMatchByContentLength() {
         Response response = client.target(server.baseUri()).path("text").request().get();
         assertThat(response, hasContentLength(equalTo(23)));
         assertThat(hasContentLength(equalTo(7)),

--- a/src/test/java/org/valid4j/matchers/http/HttpResponseMatchersTest.java
+++ b/src/test/java/org/valid4j/matchers/http/HttpResponseMatchersTest.java
@@ -1,37 +1,37 @@
 package org.valid4j.matchers.http;
 
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.Test;
 import org.valid4j.matchers.http.helpers.HttpStatus;
 
-import javax.ws.rs.core.*;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Response.StatusType;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.StatusType;
 import java.net.URI;
 import java.util.Date;
 import java.util.Locale;
 
-import static javax.ws.rs.core.MediaType.*;
-import static javax.ws.rs.core.Response.Status.*;
-import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
+import static jakarta.ws.rs.core.MediaType.*;
+import static jakarta.ws.rs.core.Response.Status.*;
+import static jakarta.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.valid4j.matchers.http.HttpResponseMatchers.*;
 import static org.valid4j.matchers.http.NewCookieMatchers.withCookieValue;
 import static org.valid4j.matchers.http.helpers.MatcherHelpers.mismatchOf;
 import static org.valid4j.matchers.http.helpers.MatcherMatchers.isDescribedBy;
 
-public class HttpResponseMatchersTest {
+class HttpResponseMatchersTest {
     private static final MediaType TEXT_WILDCARD = new MediaType("text", MEDIA_TYPE_WILDCARD);
 
     @Test
-    public void shouldMatchOkResponse() {
+    void shouldMatchOkResponse() {
         Response ok = Response.ok().build();
         assertThat(ok, isResponseOk());
         assertThat(isResponseOk(), isDescribedBy("is response ok"));
     }
 
     @Test
-    public void shouldMatchByStatusCode() {
+    void shouldMatchByStatusCode() {
         assertThat(response(BAD_REQUEST), hasStatusCode(400));
         assertThat(hasStatusCode(400),
                 isDescribedBy("has status code <400>"));
@@ -40,19 +40,19 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByStatusCodeMatcher() {
+    void shouldMatchByStatusCodeMatcher() {
         Response response = response(BAD_GATEWAY);
-        assertThat(response, hasStatusCode(isOneOf(502, 503)));
-        assertThat(hasStatusCode(isOneOf(502, 503)),
+        assertThat(response, hasStatusCode(oneOf(502, 503)));
+        assertThat(hasStatusCode(oneOf(502, 503)),
                 isDescribedBy("has status code one of {<502>, <503>}"));
         assertThat(mismatchOf(
                         response(INTERNAL_SERVER_ERROR),
-                        hasStatusCode(isOneOf(502, 503))),
+                        hasStatusCode(oneOf(502, 503))),
                 equalTo("status code was <500>"));
     }
 
     @Test
-    public void shouldMatchByStatusCodeOfFamily() {
+    void shouldMatchByStatusCodeOfFamily() {
         Response response = response(UNAUTHORIZED);
         assertThat(response, hasStatusCode(ofFamily(CLIENT_ERROR)));
         assertThat(response, hasStatusCode(CLIENT_ERROR));
@@ -65,7 +65,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByStatusCodeOfStatus() {
+    void shouldMatchByStatusCodeOfStatus() {
         Response response = response(Status.OK);
         HttpStatus okWithIgnoredReason = new HttpStatus(200, "Ignored Reason");
         assertThat(response, hasStatusCodeOf(okWithIgnoredReason));
@@ -76,7 +76,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByStatusCodeAndReason() {
+    void shouldMatchByStatusCodeAndReason() {
         Response response = response(ACCEPTED);
         assertThat(response, hasStatus(ACCEPTED));
         assertThat(response, hasStatus(202, "Accepted"));
@@ -87,7 +87,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldNotMatchByStatusCodeAndReason() {
+    void shouldNotMatchByStatusCodeAndReason() {
         Response response = response(OK);
         assertThat(response, not(hasStatus(200, "Mismatched Reason")));
         assertThat(response, not(hasStatus(new HttpStatus(200, "Mismatched Reason"))));
@@ -98,7 +98,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByHeader() {
+    void shouldMatchByHeader() {
         Response response = Response.ok().header("some-key", "some-value").build();
         assertThat(response, hasHeader("some-key"));
         assertThat(response, not(hasHeader("some-other-key")));
@@ -109,7 +109,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByHeaderWithValue() {
+    void shouldMatchByHeaderWithValue() {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<String, Object>();
         headers.add("some-key", "some-value");
         headers.add("some-key", "some-value2");
@@ -130,7 +130,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByHeaderWithValues() {
+    void shouldMatchByHeaderWithValues() {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<String, Object>();
         headers.add("some-key", "some-value");
         headers.add("some-key", "some-value2");
@@ -164,12 +164,12 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByCookie() {
+    void shouldMatchByCookie() {
         Response response = Response.ok().cookie(
-                new NewCookie("cookie1", "my-value"),
-                new NewCookie("cookie1", "my-other-value"),
-                new NewCookie("cookie1", "my-yet-another-value"),
-                new NewCookie("cookie2", "my-value-2")).build();
+                new NewCookie.Builder("cookie1").value("my-value").build(),
+            new NewCookie.Builder("cookie1").value("my-other-value").build(),
+            new NewCookie.Builder("cookie1").value("my-yet-another-value").build(),
+            new NewCookie.Builder("cookie2").value("my-value-2").build()).build();
         assertThat(response, hasCookie("cookie1"));
         assertThat(response, hasCookie("cookie2"));
         assertThat(response, not(hasCookie("cookie3")));
@@ -179,10 +179,10 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByCookieWithValue() {
+    void shouldMatchByCookieWithValue() {
         Response response = Response.ok().cookie(
-                new NewCookie("cookie1", "my-value"),
-                new NewCookie("cookie2", "my-other-value")).build();
+                new NewCookie.Builder("cookie1").value("my-value").build(),
+                new NewCookie.Builder("cookie2").value("my-other-value").build()).build();
         assertThat(response, hasCookie("cookie1", withCookieValue("my-value")));
         assertThat(response, not(hasCookie("cookie1", withCookieValue("OHASONEFN"))));
         assertThat(response, not(hasCookie("cookie3", withCookieValue("my-value"))));
@@ -192,7 +192,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByContentType() {
+    void shouldMatchByContentType() {
         Response response = Response.ok("content", TEXT_PLAIN_TYPE).build();
         assertThat(response, hasContentType(TEXT_PLAIN_TYPE));
         assertThat(response, hasContentType(TEXT_PLAIN));
@@ -207,7 +207,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByContentEncoding() {
+    void shouldMatchByContentEncoding() {
         Response response = Response.ok("content").encoding("gzip").build();
         assertThat(response, hasContentEncoding("gzip"));
         assertThat(response, not(hasContentEncoding("deflate")));
@@ -218,7 +218,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByContentLocation() {
+    void shouldMatchByContentLocation() {
         URI location = URI.create("http://example.com/loco");
         URI other = URI.create("http://example.com/poco");
         Response response = Response.ok().contentLocation(location).build();
@@ -231,7 +231,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByLanguage() {
+    void shouldMatchByLanguage() {
         Response response = Response.ok("message").language(Locale.UK).build();
         assertThat(response, ofLanguage("en-GB"));
         assertThat(response, ofLanguage(Locale.UK));
@@ -246,7 +246,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByLastModified() {
+    void shouldMatchByLastModified() {
         final long lastModMillis = 1452960194707L;
         Date lastModDate = new Date(lastModMillis);
         Response response = Response.ok().lastModified(lastModDate).build();
@@ -257,16 +257,16 @@ public class HttpResponseMatchersTest {
                 equalTo("Last-Modified was <Sat Jan 16 17:03:14 CET 2016>"));
     }
 
-    public void shouldMatchByHasLink() {
+    void shouldMatchByHasLink() {
         // TODO:
     }
 
-    public void shouldMatchByLinkByRelation() {
+    void shouldMatchByLinkByRelation() {
         // TODO:
     }
 
     @Test
-    public void shouldMatchByLocation() {
+    void shouldMatchByLocation() {
         URI location = URI.create("http://example.com/loco");
         Response response = Response.created(location).build();
         assertThat(response, hasLocation(location));
@@ -279,7 +279,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByHasEntity() {
+    void shouldMatchByHasEntity() {
         Response response = Response.ok("entity").build();
         assertThat(response, hasEntity());
         assertThat(hasEntity(), isDescribedBy("has entity"));
@@ -288,7 +288,7 @@ public class HttpResponseMatchersTest {
     }
 
     @Test
-    public void shouldMatchByHasNoEntity() {
+    void shouldMatchByHasNoEntity() {
         Response response = Response.noContent().build();
         assertThat(response, not(hasEntity()));
         assertThat(mismatchOf(response, hasEntity()),

--- a/src/test/java/org/valid4j/matchers/http/MediaTypeMatchersTest.java
+++ b/src/test/java/org/valid4j/matchers/http/MediaTypeMatchersTest.java
@@ -1,24 +1,24 @@
 package org.valid4j.matchers.http;
 
-import org.junit.Test;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
-import static javax.ws.rs.core.MediaType.*;
+import static jakarta.ws.rs.core.MediaType.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 import static org.valid4j.matchers.http.HttpResponseMatchers.compatibleWith;
 import static org.valid4j.matchers.http.helpers.MatcherHelpers.mismatchOf;
 import static org.valid4j.matchers.http.helpers.MatcherMatchers.isDescribedBy;
 
-public class MediaTypeMatchersTest {
+class MediaTypeMatchersTest {
     private static final MediaType IMAGE_WILDCARD = new MediaType("image", "*");
     private static final MediaType IMAGE_JPEG = new MediaType("image", "jpeg");
     private static final MediaType IMAGE_PNG = new MediaType("image", "png");
 
     @Test
-    public void shouldMatchCompatibleMediaType() {
+    void shouldMatchCompatibleMediaType() {
         assertThat(WILDCARD_TYPE, compatibleWith(IMAGE_JPEG));
         assertThat(IMAGE_WILDCARD, compatibleWith(IMAGE_JPEG));
         assertThat(IMAGE_WILDCARD, compatibleWith(IMAGE_PNG));
@@ -36,7 +36,7 @@ public class MediaTypeMatchersTest {
     }
 
     @Test
-    public void shouldNotMatchIncompatibleMediaType() {
+    void shouldNotMatchIncompatibleMediaType() {
         assertThat(IMAGE_PNG, not(compatibleWith(IMAGE_JPEG)));
         assertThat(IMAGE_JPEG, not(compatibleWith(IMAGE_PNG)));
         assertThat(APPLICATION_JSON_TYPE, not(compatibleWith(APPLICATION_XML_TYPE)));

--- a/src/test/java/org/valid4j/matchers/http/NewCookieMatchersTest.java
+++ b/src/test/java/org/valid4j/matchers/http/NewCookieMatchersTest.java
@@ -1,21 +1,21 @@
 package org.valid4j.matchers.http;
 
-import org.junit.Test;
 
-import javax.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.NewCookie;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 import static org.valid4j.matchers.http.NewCookieMatchers.*;
 import static org.valid4j.matchers.http.helpers.MatcherMatchers.isDescribedBy;
 
-public class NewCookieMatchersTest {
+class NewCookieMatchersTest {
 
     private static final int VERSION = 3;
     private static final int AGE = 256;
@@ -23,20 +23,19 @@ public class NewCookieMatchersTest {
     private static final boolean IS_SECURE = true;
     private static final boolean HTTP_ONLY = false;
 
-    private final NewCookie cookie = new NewCookie(
-            "cookie-name",
-            "cookie-value",
-            "/path",
-            "example.org",
-            VERSION,
-            "This is a comment",
-            AGE,
-            EXPIRY_DATE,
-            IS_SECURE,
-            HTTP_ONLY);
+    private final NewCookie cookie = new NewCookie.Builder("cookie-name")
+        .value("cookie-value")
+        .path("/path")
+        .domain("example.org")
+        .version(VERSION)
+        .comment("This is a comment")
+        .maxAge(AGE)
+        .expiry(EXPIRY_DATE)
+        .secure(IS_SECURE)
+        .httpOnly(HTTP_ONLY).build();
 
     @Test
-    public void shouldMatchOnName() {
+    void shouldMatchOnName() {
         assertThat(cookie, withCookieName("cookie-name"));
         assertThat(cookie, not(withCookieName("another-name")));
         assertThat(withCookieName("cookie-name"),
@@ -45,7 +44,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnValue() {
+    void shouldMatchOnValue() {
         assertThat(cookie, withCookieValue("cookie-value"));
         assertThat(cookie, not(withCookieValue("another-value")));
         assertThat(withCookieValue("cookie-value"),
@@ -54,7 +53,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnPath() {
+    void shouldMatchOnPath() {
         assertThat(cookie, withCookiePath(startsWith("/")));
         assertThat(cookie, not(withCookiePath(endsWith("/"))));
         assertThat(withCookiePath(startsWith("/")),
@@ -63,7 +62,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnDomain() {
+    void shouldMatchOnDomain() {
         assertThat(cookie, withCookieDomain("example.org"));
         assertThat(cookie, withCookieDomain(endsWith(".org")));
         assertThat(cookie, not(withCookieDomain(endsWith(".com"))));
@@ -73,7 +72,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnVersion() {
+    void shouldMatchOnVersion() {
         assertThat(cookie, withCookieVersion(VERSION));
         assertThat(cookie, withCookieVersion(greaterThan(2)));
         assertThat(cookie, not(withCookieVersion(lessThan(2))));
@@ -83,7 +82,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnComment() {
+    void shouldMatchOnComment() {
         assertThat(cookie, withCookieComment(containsString("is a comment")));
         assertThat(cookie, not(withCookieComment(equalTo("hi there"))));
         assertThat(withCookieComment(startsWith("This")),
@@ -92,7 +91,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnMaxAge() {
+    void shouldMatchOnMaxAge() {
         assertThat(cookie, withCookieMaxAge(lessThan(300)));
         assertThat(cookie, not(withCookieMaxAge(lessThan(200))));
         assertThat(withCookieMaxAge(lessThan(200)),
@@ -101,7 +100,7 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnExpiryDate() {
+    void shouldMatchOnExpiryDate() {
         assertThat(cookie, withCookieExpiryDate(equalTo(EXPIRY_DATE)));
 
         Date expiryDate = new Date(1461852318000L);
@@ -112,10 +111,16 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnSecureFlag() {
+    void shouldMatchOnSecureFlag() {
         assertThat(cookie, isCookieSecure());
 
-        NewCookie nonSecureCookie = new NewCookie("name", "value", "path", "domain", "comment", AGE, false);
+        NewCookie nonSecureCookie = new NewCookie.Builder("name")
+            .value("value")
+            .path("path")
+            .domain("domain")
+            .comment( "comment")
+            .maxAge(AGE)
+            .secure(false).build();
         assertThat(nonSecureCookie, not(isCookieSecure()));
 
         assertThat(isCookieSecure(),
@@ -124,10 +129,17 @@ public class NewCookieMatchersTest {
     }
 
     @Test
-    public void shouldMatchOnHttpOnlyFlag() {
+    void shouldMatchOnHttpOnlyFlag() {
         assertThat(cookie, not(isCookieHttpOnly()));
 
-        NewCookie httpOnlyCookie = new NewCookie("name", "value", "path", "domain", "comment", AGE, false, true);
+        NewCookie httpOnlyCookie = new NewCookie.Builder("name")
+            .value("value")
+            .path("path")
+            .domain("domain")
+            .comment( "comment")
+            .maxAge(AGE)
+            .secure(false)
+            .httpOnly(true).build();
         assertThat(httpOnlyCookie, isCookieHttpOnly());
 
         assertThat(isCookieHttpOnly(),

--- a/src/test/java/org/valid4j/matchers/http/helpers/HttpStatus.java
+++ b/src/test/java/org/valid4j/matchers/http/helpers/HttpStatus.java
@@ -1,9 +1,9 @@
 package org.valid4j.matchers.http.helpers;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 /**
- * Implementation class of a {@link javax.ws.rs.core.Response.StatusType}
+ * Implementation class of a {@link jakarta.ws.rs.core.Response.StatusType}
  */
 public class HttpStatus implements Response.StatusType {
 


### PR DESCRIPTION
Recently lots of projects are migrating to Jakarta EE 9, which entails a change of package name from javax to jakarta. This test library does not use the new package name, making it difficult to continue using it.

This PR fixes that, but also does a full upgrade of all the dependencies of the projects that are sometimes quite old.